### PR TITLE
Set version number so library is seen as stable by composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,6 @@
         "psr-0": {
             "RocketShipIt": "src"
         }
-    }
+    },
+    "version": "1.0.0"    
 }


### PR DESCRIPTION
Add a version so that the library reflects 'stable' stability level. As is, to use this package you have to set "minimum-stability": "dev" in the app that is pulling it in, where "minimum-stability": "stable" would be nice to have.

https://getcomposer.org/doc/02-libraries.md#library-versioning If you'd prefer a more specific versioning system, there are notes here https://getcomposer.org/doc/articles/versions.md

Thanks