### PR TITLE
Update composer.json and tag release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,5 @@
         "psr-0": {
             "RocketShipIt": "src"
         }
-    },
-    "version": "1.0.0"    
+    }
 }


### PR DESCRIPTION
Set releases instead with tags. If you could merge this then tag add a 1.0.0 tag, and push that, the package could be seen as stable by composer.

Details: I had suggested the change I'm undoing here as a way to make packagist see this package as stable. I think I was wrong based on this info https://getcomposer.org/doc/02-libraries.md#library-versioning , apologies for that error. Based on the "Managing package versions" section of this page https://packagist.org/about I believe if you could a) commit this change (as the tags mentioned next will instead dictate the version) and b) tag a release called 1.0.0 or a similar version notation you'd prefer to mark a stable release? Thank you